### PR TITLE
Add support for more cachable file types in CacheManifestLinker

### DIFF
--- a/documentation/mobile-offline.asciidoc
+++ b/documentation/mobile-offline.asciidoc
@@ -154,6 +154,18 @@ offline application. If you use any Vaadin widgets, as described in
 <<dummy/../../framework/clientsidewidgets/clientsidewidgets-vaadin#clientsidewidgets.vaadin,"Vaadin
 Widgets">>, they will use the Vaadin theme.
 
+Note that cache manifest file will only include files with the following extensions:
+".html", ".js", ".css", ".png", ".jpg", ".gif", ".ico", ".svg", ".woff".
+If you need to cache more file types, you have to add the corresponding file
+extension(s) to your widget set definition file as follows.
 
-
+[subs="normal"]
+----
+&lt;set-configuration-property
+    name='touchkit.manifestlinker.additionalCacheFileExtension'
+    value='.ttf' /&gt;
+&lt;set-configuration-property
+    name='touchkit.manifestlinker.additionalCacheFileExtension'
+    value='.otf' /&gt;
+----
 

--- a/vaadin-touchkit-agpl/src/main/java/com/vaadin/addon/touchkit/gwt/CacheManifestLinker.java
+++ b/vaadin-touchkit-agpl/src/main/java/com/vaadin/addon/touchkit/gwt/CacheManifestLinker.java
@@ -1,31 +1,13 @@
 package com.vaadin.addon.touchkit.gwt;
 
-import java.io.File;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.Set;
-import java.util.SortedMap;
-import java.util.SortedSet;
-import java.util.TreeSet;
-
 import com.google.gwt.core.ext.LinkerContext;
 import com.google.gwt.core.ext.TreeLogger;
 import com.google.gwt.core.ext.UnableToCompleteException;
-import com.google.gwt.core.ext.linker.AbstractLinker;
-import com.google.gwt.core.ext.linker.Artifact;
-import com.google.gwt.core.ext.linker.ArtifactSet;
-import com.google.gwt.core.ext.linker.CompilationResult;
-import com.google.gwt.core.ext.linker.ConfigurationProperty;
-import com.google.gwt.core.ext.linker.EmittedArtifact;
-import com.google.gwt.core.ext.linker.LinkerOrder;
-import com.google.gwt.core.ext.linker.SelectionProperty;
-import com.google.gwt.core.ext.linker.Shardable;
+import com.google.gwt.core.ext.linker.*;
+
+import java.io.File;
+import java.util.*;
+import java.util.Map.Entry;
 
 /**
  * A GWT linker that produces a cache.manifest file describing what to cache in
@@ -170,6 +152,14 @@ public class CacheManifestLinker extends AbstractLinker {
                     .getConfigurationProperties();
             for (ConfigurationProperty configurationProperty : configurationProperties) {
                 if (configurationProperty.getName().equals(
+                        "touchkit.manifestlinker.additionalCacheFileExtension")) {
+                    List<String> values = configurationProperty.getValues();
+                    for (String value : values) {
+                        acceptedFileExtensions.add("." + value);
+                    }
+                    break;
+                }
+                if (configurationProperty.getName().equals(
                         "touchkit.manifestlinker.additionalCacheRoot")) {
                     List<String> values = configurationProperty.getValues();
                     for (String root : values) {
@@ -222,7 +212,7 @@ public class CacheManifestLinker extends AbstractLinker {
     }
 
     List<String> acceptedFileExtensions = Arrays.asList(".html", ".js", ".css",
-            ".png", ".jpg", ".gif", ".ico", ".woff");
+            ".png", ".jpg", ".gif", ".ico", ".svg", ".woff");
 
     protected boolean acceptCachedResource(String filename) {
         if (filename.startsWith("compile-report/")) {

--- a/vaadin-touchkit-agpl/src/main/java/com/vaadin/addon/touchkit/gwt/CacheManifestLinker.java
+++ b/vaadin-touchkit-agpl/src/main/java/com/vaadin/addon/touchkit/gwt/CacheManifestLinker.java
@@ -155,7 +155,7 @@ public class CacheManifestLinker extends AbstractLinker {
                         "touchkit.manifestlinker.additionalCacheFileExtension")) {
                     List<String> values = configurationProperty.getValues();
                     for (String value : values) {
-                        acceptedFileExtensions.add("." + value);
+                        acceptedFileExtensions.add(value);
                     }
                     break;
                 }

--- a/vaadin-touchkit-agpl/src/main/java/com/vaadin/addon/touchkit/gwt/TouchKitWidgetSet.gwt.xml
+++ b/vaadin-touchkit-agpl/src/main/java/com/vaadin/addon/touchkit/gwt/TouchKitWidgetSet.gwt.xml
@@ -92,6 +92,9 @@
         class="com.vaadin.addon.touchkit.gwt.client.VEagerResourceLoader" />
 
     <define-configuration-property
+        name='touchkit.manifestlinker.additionalCacheFileExtension' is-multi-valued='true' />
+
+    <define-configuration-property
         name='touchkit.manifestlinker.additionalCacheRoot' is-multi-valued='true' />
 
     <define-linker name="touchkitcachemanifest"


### PR DESCRIPTION
At the moment only a small set of hard coded file types (mostly image types) are cached through the cache manifest generated by CacheManifestLinker.

This patch
- extends the supported file types by the popular vector graphics format "svg",
- adds a configuration property "touchkit.manifestlinker.additionalCacheFileExtension" for widgetset configuration files to allow users to extends the list of cached file types and 
- adds the asciidoc documentation for the new property

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/touchkit/1)
<!-- Reviewable:end -->
