### PR TITLE
fix: support newer Firefox without appcache

### DIFF
--- a/vaadin-touchkit-agpl/src/main/java/com/vaadin/addon/touchkit/settings/TouchKitSettings.java
+++ b/vaadin-touchkit-agpl/src/main/java/com/vaadin/addon/touchkit/settings/TouchKitSettings.java
@@ -456,7 +456,7 @@ public class TouchKitSettings implements BootstrapListener,
             VaadinRequest currentRequest = VaadinServletService.getCurrentRequest();
             String useragentheader = currentRequest.getHeader("User-Agent").toLowerCase();
             // Simply expect all chromes to support
-            if (useragentheader.contains("chrome")) {
+            if (useragentheader.contains("chrome") || useragentheader.contains("firefox")) {
                 return true;
             }
         } catch (Exception e) {


### PR DESCRIPTION
## Description

This fix should support newer Firefox version without app cache support

Fixes # (issue)

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [ ] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [ ] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
